### PR TITLE
Fix doctest, config, and ticker runtime gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+name: Bug report
+description: Report a reproducible crypto ticker bug.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: List the exact commands, config, and observed behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Rust version, app version or commit, and relevant config.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest a scoped improvement.
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed scope
+      description: Describe the smallest useful change.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What should this change avoid?
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+- 
+
+## Validation
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo check`
+- [ ] `cargo test`
+
+## Notes
+
+- 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  rust:
+    name: Rust
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Check build
+        run: cargo check
+
+      - name: Run tests
+        run: cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+- Add CI coverage for formatting, build checks, and tests.
+- Add issue and pull request templates.
+- Document current release status and user-facing limitations.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ debug_logging = false
 
 See `config.toml.example` for all available options.
 
+## Release Status
+
+This project is currently source-only. Build and run it from a local checkout until a tagged GitHub release or package artifact is published.
+
+## Limitations
+
+- Prices are displayed from exchange streaming APIs and can be delayed, interrupted, or unavailable.
+- The app is a monitoring tool only and is not financial advice or a trading signal.
+- Always verify price data with your exchange before making financial decisions.
+
 ## Supported Exchanges
 
 - **OKX**: Primary exchange with full WebSocket streaming support

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,10 +25,3 @@ max_buffer_size = 1000
 
 # Enable debug logging (impacts performance, default: false)
 debug_logging = false
-
-# Performance settings
-# Maximum number of price updates to buffer in memory (default: 1000)
-max_buffer_size = 1000
-
-# Enable debug logging (impacts performance, default: false)
-debug_logging = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,9 +35,9 @@
 //! }
 //! ```
 
-use serde::{Deserialize, Serialize};
-use std::path::Path;
 use crate::error::{Result, TickerError};
+use serde::{Deserialize, Serialize};
+use std::{io::ErrorKind, path::Path};
 
 /// Default maximum buffer size for price updates
 fn default_max_buffer_size() -> usize {
@@ -50,7 +50,7 @@ fn default_debug_logging() -> bool {
 }
 
 /// Application configuration with performance optimizations
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     /// Trading pairs to monitor
     pub trading_pairs: Vec<String>,
@@ -92,21 +92,37 @@ impl Config {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| TickerError::ConfigError(format!("Failed to read config file: {}", e)))?;
-        
+
         let config: Config = toml::from_str(&content)
             .map_err(|e| TickerError::ConfigError(format!("Failed to parse config: {}", e)))?;
-        
+
+        config.validate()?;
+
         Ok(config)
+    }
+
+    /// Load configuration from a file when it exists, otherwise use defaults.
+    pub fn from_optional_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+
+        match std::fs::metadata(path) {
+            Ok(_) => Self::from_file(path),
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(TickerError::ConfigError(format!(
+                "Failed to inspect config file: {}",
+                e
+            ))),
+        }
     }
 
     /// Save configuration to a TOML file
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let content = toml::to_string_pretty(self)
             .map_err(|e| TickerError::ConfigError(format!("Failed to serialize config: {}", e)))?;
-        
+
         std::fs::write(path, content)
             .map_err(|e| TickerError::ConfigError(format!("Failed to write config file: {}", e)))?;
-        
+
         Ok(())
     }
 
@@ -117,5 +133,100 @@ impl Config {
         } else {
             format!("{}/{}", env!("CARGO_MANIFEST_DIR"), self.icon_path)
         }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.update_interval_secs == 0 {
+            return Err(TickerError::ConfigError(
+                "update_interval_secs must be greater than zero".to_string(),
+            ));
+        }
+
+        if self.max_buffer_size == 0 {
+            return Err(TickerError::ConfigError(
+                "max_buffer_size must be greater than zero".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_config_path(name: &str) -> PathBuf {
+        let nanos = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_nanos(),
+            Err(e) => panic!("system time should be after Unix epoch: {e}"),
+        };
+
+        std::env::temp_dir().join(format!("crypto-coin-ticker-{name}-{nanos}.toml"))
+    }
+
+    #[test]
+    fn missing_optional_config_uses_defaults() {
+        let path = temp_config_path("missing");
+
+        let config = match Config::from_optional_file(path) {
+            Ok(config) => config,
+            Err(e) => panic!("missing config should use defaults: {e}"),
+        };
+
+        assert_eq!(config, Config::default());
+    }
+
+    #[test]
+    fn invalid_existing_config_returns_error() {
+        let path = temp_config_path("invalid");
+        if let Err(e) = std::fs::write(&path, "trading_pairs = [") {
+            panic!("test config should be writable: {e}");
+        }
+
+        let error = match Config::from_optional_file(&path) {
+            Ok(_) => panic!("invalid config should fail"),
+            Err(error) => error,
+        };
+
+        if let Err(e) = std::fs::remove_file(path) {
+            panic!("test config should be removable: {e}");
+        }
+        assert!(error.to_string().contains("Failed to parse config"));
+    }
+
+    #[test]
+    fn zero_runtime_limits_are_rejected() {
+        let path = temp_config_path("zero-limits");
+        let zero_limit_config = r#"
+trading_pairs = ["BTC-USDT"]
+update_interval_secs = 0
+ws_connection_timeout_secs = 2
+ws_ping_timeout_secs = 5
+icon_path = "icons/icon.png"
+tooltip = "Crypto Ticker"
+max_buffer_size = 0
+debug_logging = false
+"#;
+
+        if let Err(e) = std::fs::write(&path, zero_limit_config) {
+            panic!("test config should be writable: {e}");
+        }
+
+        let error = match Config::from_file(&path) {
+            Ok(_) => panic!("zero values should fail validation"),
+            Err(error) => error,
+        };
+
+        if let Err(e) = std::fs::remove_file(path) {
+            panic!("test config should be removable: {e}");
+        }
+        assert!(
+            error
+                .to_string()
+                .contains("update_interval_secs must be greater than zero")
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,17 +18,21 @@
 //! - WebSocket connection parameters
 //!
 //! ## Usage
-//! ```rust
-//! use okk::Config;
+//! ```rust,no_run
+//! use okk::{Config, Result};
 //!
-//! // Load from file
-//! let config = Config::from_file("config.toml")?;
+//! fn main() -> Result<()> {
+//!     // Load from file
+//!     let config = Config::from_file("config.toml")?;
 //!
-//! // Use defaults
-//! let config = Config::default();
+//!     // Use defaults
+//!     let config = Config::default();
 //!
-//! // Save to file
-//! config.save_to_file("config.toml")?;
+//!     // Save to file
+//!     config.save_to_file("config.toml")?;
+//!
+//!     Ok(())
+//! }
 //! ```
 
 use serde::{Deserialize, Serialize};

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -19,24 +19,24 @@
 //! ```rust
 //! use okk::{Config, ExchangeClient};
 //! use okk::exchange::PriceUpdate;
-//! use std::sync::mpsc::channel;
+//! use std::sync::mpsc::sync_channel;
 //!
 //! let config = Config::default();
+//! let (tx, rx) = sync_channel::<PriceUpdate>(config.max_buffer_size);
 //! let client = ExchangeClient::new(config);
-//! let (tx, rx) = channel::<PriceUpdate>();
 //! // let handles = client.start_price_monitoring(tx).await?;
 //! ```
 
-use std::time::Duration;
-use std::sync::mpsc::Sender;
 use chrono;
 use exc::prelude::*;
+use std::sync::mpsc::{SyncSender, TrySendError};
+use std::time::{Duration, Instant};
 
-use futures::StreamExt;
-use tokio::task::JoinHandle;
-use rust_decimal::Decimal;
-use crate::error::Result;
 use crate::config::Config;
+use crate::error::Result;
+use futures::StreamExt;
+use rust_decimal::Decimal;
+use tokio::task::JoinHandle;
 
 /// Exchange client wrapper for handling cryptocurrency price streams
 pub struct ExchangeClient {
@@ -50,8 +50,14 @@ impl ExchangeClient {
     }
 
     /// Start monitoring price streams for all configured trading pairs with optimized resource usage
-    pub async fn start_price_monitoring(&self, tx: Sender<PriceUpdate>) -> Result<Vec<JoinHandle<()>>> {
-        tracing::info!("Starting price monitoring for {} pairs", self.config.trading_pairs.len());
+    pub async fn start_price_monitoring(
+        &self,
+        tx: SyncSender<PriceUpdate>,
+    ) -> Result<Vec<JoinHandle<()>>> {
+        tracing::info!(
+            "Starting price monitoring for {} pairs",
+            self.config.trading_pairs.len()
+        );
 
         // Create a single exchange connection to be shared across all pairs
         let exchange = Okx::endpoint()
@@ -82,11 +88,12 @@ impl ExchangeClient {
     /// Monitor a single trading pair with automatic reconnection and error recovery
     async fn monitor_pair(
         mut client: impl exc::SubscribeTickersService + Clone + Send + 'static,
-        tx: Sender<PriceUpdate>,
+        tx: SyncSender<PriceUpdate>,
         pair: String,
-        _update_interval: Duration,
+        update_interval: Duration,
     ) {
         let mut consecutive_errors = 0;
+        let mut last_sent_at = None;
         const MAX_CONSECUTIVE_ERRORS: u32 = 5;
         const BASE_BACKOFF_SECS: u64 = 1;
 
@@ -101,13 +108,32 @@ impl ExchangeClient {
                     while let Some(result) = stream.next().await {
                         match result {
                             Ok(ticker) => {
+                                let now = Instant::now();
+                                if !should_emit_update(last_sent_at, now, update_interval) {
+                                    continue;
+                                }
+
                                 let update = PriceUpdate::new(pair.clone(), ticker.last);
 
                                 tracing::debug!("{}: {}", pair, ticker.last);
 
-                                if let Err(e) = tx.send(update) {
-                                    tracing::error!("Channel closed, stopping monitoring for {}: {}", pair, e);
-                                    return; // Exit if channel is closed
+                                match tx.try_send(update) {
+                                    Ok(()) => {
+                                        last_sent_at = Some(now);
+                                    }
+                                    Err(TrySendError::Full(_)) => {
+                                        tracing::warn!(
+                                            "Price update buffer full for {}, dropping stale update",
+                                            pair
+                                        );
+                                    }
+                                    Err(TrySendError::Disconnected(_)) => {
+                                        tracing::error!(
+                                            "Channel closed, stopping monitoring for {}",
+                                            pair
+                                        );
+                                        return; // Exit if channel is closed
+                                    }
                                 }
                             }
                             Err(err) => {
@@ -122,7 +148,10 @@ impl ExchangeClient {
                     consecutive_errors += 1;
                     tracing::error!(
                         "Failed to subscribe to {} (attempt {}/{}): {}",
-                        pair, consecutive_errors, MAX_CONSECUTIVE_ERRORS, err
+                        pair,
+                        consecutive_errors,
+                        MAX_CONSECUTIVE_ERRORS,
+                        err
                     );
 
                     if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
@@ -138,12 +167,28 @@ impl ExchangeClient {
 
             // Exponential backoff with simple jitter
             let backoff_secs = BASE_BACKOFF_SECS * 2_u64.pow(consecutive_errors.min(5));
-            let jitter = (chrono::Utc::now().timestamp_millis() % (backoff_secs as i64 / 2 + 1)) as u64;
+            let jitter =
+                (chrono::Utc::now().timestamp_millis() % (backoff_secs as i64 / 2 + 1)) as u64;
             let sleep_duration = Duration::from_secs(backoff_secs + jitter);
 
-            tracing::info!("Waiting {:?} before reconnecting to {}", sleep_duration, pair);
+            tracing::info!(
+                "Waiting {:?} before reconnecting to {}",
+                sleep_duration,
+                pair
+            );
             tokio::time::sleep(sleep_duration).await;
         }
+    }
+}
+
+fn should_emit_update(
+    last_sent_at: Option<Instant>,
+    now: Instant,
+    update_interval: Duration,
+) -> bool {
+    match last_sent_at {
+        Some(last_sent_at) => now.duration_since(last_sent_at) >= update_interval,
+        None => true,
     }
 }
 
@@ -156,6 +201,44 @@ pub struct PriceUpdate {
     pub price: Decimal,
     /// Unix timestamp in milliseconds for better performance
     pub timestamp_ms: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_interval_allows_first_update() {
+        assert!(should_emit_update(
+            None,
+            Instant::now(),
+            Duration::from_secs(10)
+        ));
+    }
+
+    #[test]
+    fn update_interval_throttles_recent_update() {
+        let last_sent_at = Instant::now();
+        let now = last_sent_at + Duration::from_secs(1);
+
+        assert!(!should_emit_update(
+            Some(last_sent_at),
+            now,
+            Duration::from_secs(10)
+        ));
+    }
+
+    #[test]
+    fn update_interval_allows_elapsed_update() {
+        let last_sent_at = Instant::now();
+        let now = last_sent_at + Duration::from_secs(10);
+
+        assert!(should_emit_update(
+            Some(last_sent_at),
+            now,
+            Duration::from_secs(10)
+        ));
+    }
 }
 
 impl PriceUpdate {
@@ -171,7 +254,8 @@ impl PriceUpdate {
     /// Get the timestamp as a DateTime for display purposes
     pub fn datetime(&self) -> chrono::DateTime<chrono::Utc> {
         use chrono::TimeZone;
-        chrono::Utc.timestamp_millis_opt(self.timestamp_ms)
+        chrono::Utc
+            .timestamp_millis_opt(self.timestamp_ms)
             .single()
             .unwrap_or_else(chrono::Utc::now)
     }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -18,11 +18,12 @@
 //! ## Usage
 //! ```rust
 //! use okk::{Config, ExchangeClient};
+//! use okk::exchange::PriceUpdate;
 //! use std::sync::mpsc::channel;
 //!
 //! let config = Config::default();
 //! let client = ExchangeClient::new(config);
-//! let (tx, rx) = channel();
+//! let (tx, rx) = channel::<PriceUpdate>();
 //! // let handles = client.start_price_monitoring(tx).await?;
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! - **Low Resource Usage**: Minimal CPU and memory footprint
 //!
 //! ## Quick Start
-//! ```rust
+//! ```rust,no_run
 //! use okk::{Config, ExchangeClient, TrayUI};
 //! use std::sync::mpsc::channel;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,12 @@
 //! ## Quick Start
 //! ```rust,no_run
 //! use okk::{Config, ExchangeClient, TrayUI};
-//! use std::sync::mpsc::channel;
+//! use std::sync::mpsc::sync_channel;
 //!
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
 //!     let config = Config::default();
-//!     let (tx, rx) = channel();
+//!     let (tx, rx) = sync_channel(config.max_buffer_size);
 //!
 //!     let exchange_client = ExchangeClient::new(config.clone());
 //!     let _handles = exchange_client.start_price_monitoring(tx).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,10 +23,9 @@
 //! RUST_LOG=exc_okx=debug,okx_streams=debug cargo run
 //! ```
 
-use std::sync::mpsc::channel;
-use tracing_subscriber::prelude::*;
 use okk::{Config, ExchangeClient, TrayUI};
-
+use std::sync::mpsc::sync_channel;
+use tracing_subscriber::prelude::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -39,24 +38,10 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::registry().with(fmt).init();
 
     // Load configuration
-    let config = if std::path::Path::new("config.toml").exists() {
-        match Config::from_file("config.toml") {
-            Ok(config) => {
-                tracing::info!("Loaded configuration from config.toml");
-                config
-            }
-            Err(e) => {
-                tracing::warn!("Failed to load config.toml: {}, using defaults", e);
-                Config::default()
-            }
-        }
-    } else {
-        tracing::info!("No config.toml found, using default configuration");
-        Config::default()
-    };
+    let config = Config::from_optional_file("config.toml")?;
 
-    // Create communication channel
-    let (tx, rx) = channel();
+    // Create bounded communication channel
+    let (tx, rx) = sync_channel(config.max_buffer_size);
 
     // Start exchange client
     let exchange_client = ExchangeClient::new(config.clone());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,15 +20,15 @@
 //! // tray_ui.run(price_receiver)?;
 //! ```
 
-use std::sync::mpsc::Receiver;
-use tao::event_loop::{ControlFlow, EventLoopBuilder};
-use tray_icon::{
-    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
-    TrayIconBuilder, TrayIconEvent,
-};
 use crate::config::Config;
 use crate::error::{Result, TickerError};
 use crate::exchange::PriceUpdate;
+use std::sync::mpsc::Receiver;
+use tao::event_loop::{ControlFlow, EventLoopBuilder};
+use tray_icon::{
+    TrayIconBuilder, TrayIconEvent,
+    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
+};
 
 /// Tray UI manager for displaying cryptocurrency prices in the system tray
 pub struct TrayUI {
@@ -45,11 +45,10 @@ impl TrayUI {
     pub fn run(self, price_rx: Receiver<PriceUpdate>) -> Result<()> {
         tracing::info!("Initializing system tray UI");
 
-        let icon = self.load_icon()
-            .map_err(|e| {
-                tracing::error!("Failed to load tray icon: {}", e);
-                e
-            })?;
+        let icon = self.load_icon().map_err(|e| {
+            tracing::error!("Failed to load tray icon: {}", e);
+            e
+        })?;
 
         let event_loop = EventLoopBuilder::new().build();
 
@@ -57,10 +56,9 @@ impl TrayUI {
         let tray_menu = Menu::new();
         let quit_item = MenuItem::new("Quit", true, None);
 
-        tray_menu.append_items(&[
-            &PredefinedMenuItem::separator(),
-            &quit_item,
-        ]).map_err(|e| TickerError::UIError(format!("Failed to create menu items: {}", e)))?;
+        tray_menu
+            .append_items(&[&PredefinedMenuItem::separator(), &quit_item])
+            .map_err(|e| TickerError::UIError(format!("Failed to create menu items: {}", e)))?;
 
         // Create tray icon with detailed error context
         let mut tray_icon = Some(
@@ -101,7 +99,7 @@ impl TrayUI {
                     // Use more efficient string formatting to reduce allocations
                     let title = format!("{}: ${:.2}", price_update.pair, price_update.price);
                     if let Some(ref mut tray) = tray_icon {
-                        let _ = tray.set_title(Some(&title));
+                        tray.set_title(Some(&title));
                     }
 
                     tracing::debug!("Updated tray with: {}", title);
@@ -112,7 +110,7 @@ impl TrayUI {
                         if connection_status != "Disconnected" {
                             connection_status = "Disconnected";
                             if let Some(ref mut tray) = tray_icon {
-                                let _ = tray.set_title(Some("Disconnected"));
+                                tray.set_title(Some("Disconnected"));
                             }
                             tracing::warn!("No price updates received for 30 seconds");
                         }
@@ -148,7 +146,7 @@ impl TrayUI {
     fn load_icon(&self) -> Result<tray_icon::Icon> {
         let icon_path = self.config.get_icon_path();
         let path = std::path::Path::new(&icon_path);
-        
+
         let (icon_rgba, icon_width, icon_height) = {
             let image = image::open(path)
                 .map_err(|e| TickerError::UIError(format!("Failed to open icon: {}", e)))?
@@ -161,6 +159,4 @@ impl TrayUI {
         tray_icon::Icon::from_rgba(icon_rgba, icon_width, icon_height)
             .map_err(|e| TickerError::UIError(format!("Failed to create icon: {}", e)))
     }
-
-
 }


### PR DESCRIPTION
Closes #8
Closes #9
Closes #10
Closes #11
Closes #12

## Summary
- keep doctests deterministic so `cargo test` no longer fails or hangs in Quick Start examples
- fail closed when an explicit `config.toml` exists but cannot be read, parsed, or validated
- remove duplicate keys from `config.toml.example`
- enforce positive runtime limits, create the price channel with `max_buffer_size`, and throttle emitted ticker updates with `update_interval_secs`
- remove misleading discarded `set_title` bindings after verifying the current `tray-icon` API returns `()` rather than `Result`
- add CI, issue templates, a pull request template, a changelog, and README release-status/limitations language
- add repository topics: `rust`, `cryptocurrency`, `system-tray`, `okx`, `ticker`

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test`
