### PR TITLE
Replace vulnerable exchange dependency chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,28 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom 0.2.10",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -108,28 +86,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,12 +107,6 @@ dependencies = [
  "libc",
  "system-deps",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "autocfg"
@@ -203,18 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,11 +166,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -242,24 +180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -269,29 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "borsh"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -307,38 +210,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
-name = "bytecheck"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "byteorder-lite"
@@ -358,7 +233,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -411,10 +286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -426,9 +306,8 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -448,10 +327,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -475,7 +354,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -488,16 +367,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "libc",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -509,20 +388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -548,35 +413,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -586,47 +434,11 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.104",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -636,37 +448,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
-name = "deranged"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
-dependencies = [
- "powerfmt",
- "serde",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -702,8 +491,19 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -736,12 +536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,190 +566,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "exc"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a704dcab1060eaaea59dda54152cd4c1d2ebcbcd92b29122524bf7aed9089c1"
-dependencies = [
- "anyhow",
- "async-stream",
- "either",
- "exc-binance",
- "exc-core",
- "exc-okx",
- "futures",
- "futures-util",
- "rust_decimal",
- "time",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "exc-binance"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b3528aff2d2a53494952e17790165b7c7b293a02b382efaff89ca7835c7216"
-dependencies = [
- "anyhow",
- "async-stream",
- "cfg-if",
- "either",
- "exc-core",
- "futures",
- "hex",
- "hmac",
- "http",
- "hyper",
- "pin-project-lite",
- "rust_decimal",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "serde_with 3.14.0",
- "sha2",
- "thiserror 1.0.47",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-tower",
- "tokio-tungstenite",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "exc-core"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfc4012c7e97531411bb8a82a39097dc2b8e78dd95baa4254120ecb007daee8"
-dependencies = [
- "anyhow",
- "async-stream",
- "cfg-if",
- "either",
- "exc-make",
- "exc-service",
- "exc-symbol",
- "exc-types",
- "futures",
- "http",
- "hyper",
- "hyper-rustls",
- "indicator",
- "num-traits",
- "pin-project-lite",
- "positions",
- "rust_decimal",
- "serde",
- "thiserror 1.0.47",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "exc-make"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521568ac0817932cb4c93d652096b3fd169f2cf80962aceabca00ab5a858511d"
-dependencies = [
- "exc-service",
- "exc-types",
- "futures",
- "tower-make",
- "tower-service",
-]
-
-[[package]]
-name = "exc-okx"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5f8356368faafeb6e9da79fcb81a2947bfdbd4ef9d323d971673a71499c6d1"
-dependencies = [
- "anyhow",
- "async-stream",
- "atomic-waker",
- "base64 0.21.7",
- "cfg-if",
- "either",
- "exc-core",
- "futures",
- "hmac",
- "http",
- "hyper",
- "pin-project-lite",
- "rust_decimal",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_with 3.14.0",
- "sha2",
- "thiserror 1.0.47",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-tower",
- "tokio-tungstenite",
- "tower",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "exc-service"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebecbf012b34262832c00fc5daeee97b6d40e1e082c8904ac17fb28af834082a"
-dependencies = [
- "anyhow",
- "futures",
- "humantime",
- "hyper",
- "pin-project-lite",
- "thiserror 1.0.47",
- "tokio",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "exc-symbol"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b86af94151ef3d8399c9dd131526ae38d23bd09806401c56dd7a32a667f3a98"
-dependencies = [
- "positions",
- "rust_decimal",
- "thiserror 1.0.47",
- "time",
-]
-
-[[package]]
-name = "exc-types"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6fe7e3d234b95374d6028b4bb907f49ad46acb8fa51174c4c0c18330224318"
-dependencies = [
- "derive_more",
- "exc-service",
- "exc-symbol",
- "futures",
- "indicator",
- "num-traits",
- "positions",
- "rust_decimal",
- "serde",
- "thiserror 1.0.47",
- "time",
-]
 
 [[package]]
 name = "exr"
@@ -1012,14 +622,8 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.8",
+ "spin",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -1050,18 +654,12 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1238,16 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,8 +856,20 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1326,7 +926,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1441,25 +1041,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.3",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
@@ -1471,40 +1052,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "http"
-version = "0.2.9"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1514,53 +1068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "hyper"
-version = "0.14.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.4.9",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "rustls",
- "tokio",
- "tokio-rustls",
- "webpki-roots",
+ "typenum",
 ]
 
 [[package]]
@@ -1587,19 +1100,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
+name = "icu_collections"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1643,39 +1242,12 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
- "serde",
-]
-
-[[package]]
-name = "indicator"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decd08f8230118c3616f847848450a2da464bf29a0aa27716317c60fc9d41888"
-dependencies = [
- "arrayvec",
- "futures",
- "pin-project-lite",
- "thiserror 1.0.47",
- "time",
- "tinyvec",
- "tracing",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1757,7 +1329,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -1830,7 +1402,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -1852,6 +1424,12 @@ dependencies = [
  "libc",
  "x11",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1984,7 +1562,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2051,12 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,7 +1686,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -2135,7 +1707,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2147,7 +1719,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -2158,7 +1730,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "objc2-core-foundation",
 ]
 
@@ -2174,7 +1746,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -2195,13 +1767,13 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
- "exc",
  "futures",
  "image",
- "rust_decimal",
  "serde",
+ "serde_json",
  "tao",
  "tokio",
+ "tokio-tungstenite",
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
@@ -2213,6 +1785,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2276,9 +1854,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
@@ -2332,24 +1910,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "positions"
-version = "0.2.1"
+name = "potential_utf"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4af0dfb9b5cf4e252de21f211925b9ece9f3af1548ce077c9755db7d6f3c21"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "hashbrown 0.13.2",
- "num-traits",
- "serde",
- "serde_with 2.3.3",
- "smol_str",
- "thiserror 1.0.47",
+ "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2374,15 +1941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.7",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2438,26 +1996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,10 +2026,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2501,7 +2039,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2511,7 +2060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2522,6 +2071,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.10",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rav1e"
@@ -2549,7 +2104,7 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
+ "rand 0.8.6",
  "rand_chacha",
  "simd_helpers",
  "system-deps",
@@ -2620,26 +2175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,34 +2192,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "rend"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
 
 [[package]]
 name = "ring"
@@ -2696,52 +2207,8 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.10",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.7.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
-dependencies = [
- "bitvec",
- "bytecheck",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2761,24 +2228,47 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "log",
- "ring 0.17.14",
+ "once_cell",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2786,12 +2276,6 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
-
-[[package]]
-name = "ryu"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -2803,27 +2287,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
+name = "schannel"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2833,20 +2302,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.0"
+name = "security-framework"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
+name = "security-framework-sys"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2856,45 +2332,45 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.47",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2907,87 +2383,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "serde",
- "serde_with_macros 2.3.3",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.10.0",
- "schemars 0.9.0",
- "schemars 1.0.3",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros 3.14.0",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3025,12 +2424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,28 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
-
-[[package]]
-name = "smol_str"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -3076,12 +2450,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -3090,10 +2458,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "stable_deref_trait"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"
@@ -3124,6 +2492,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,7 +2532,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
@@ -3185,12 +2575,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -3260,50 +2644,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.41"
+name = "tinystr"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
+ "displaydoc",
+ "zerovec",
 ]
-
-[[package]]
-name = "time-core"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
-
-[[package]]
-name = "time-macros"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3316,7 +2664,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -3334,69 +2682,28 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "tokio-tower"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4322b6e2ebfd3be4082c16df4341505ef333683158b55f22afaf3f61565d728"
-dependencies = [
- "crossbeam",
- "futures-core",
- "futures-sink",
- "futures-util",
- "pin-project",
- "tokio",
- "tower",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -3438,7 +2745,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3451,7 +2758,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap",
  "toml_datetime",
  "winnow 0.5.15",
 ]
@@ -3462,7 +2769,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3477,51 +2784,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-
-[[package]]
-name = "tower-make"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-dependencies = [
- "tower-service",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3599,57 +2866,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.10.2",
  "rustls",
+ "rustls-pki-types",
  "sha1",
- "thiserror 1.0.47",
- "url",
- "utf-8",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3659,41 +2903,27 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8_iter"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "uuid"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
-dependencies = [
- "getrandom 0.2.10",
-]
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "v_frame"
@@ -3732,15 +2962,6 @@ checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -3817,22 +3038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
 name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,7 +3092,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -3908,7 +3113,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -3920,7 +3125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -3953,13 +3158,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3968,7 +3179,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3977,7 +3188,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4014,6 +3225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4084,7 +3304,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4093,7 +3313,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4300,17 +3520,14 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
+name = "writeable"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x11"
@@ -4332,6 +3549,95 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,15 @@ anyhow = "1.0.98"
 tokio = { version = "1.45.1", features = ["rt-multi-thread", "net", "time", "sync", "macros"] }
 
 # Exchange API
-exc = { version = "0.7.3", features = ["okx"] }
 futures = "0.3.31"
+tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-native-roots"] }
 
 # Data types
-rust_decimal = "1.37.2"
 chrono = "0.4.41"
 
 # Configuration and serialization
-serde = "1.0.219"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.151"
 toml = "0.8.23"
 
 # Logging

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This project is currently source-only. Build and run it from a local checkout un
 ## Supported Exchanges
 
 - **OKX**: Primary exchange with full WebSocket streaming support
-- Extensible architecture for additional exchanges
+- Additional exchanges require a new streaming client implementation
 
 ## Architecture
 
@@ -85,7 +85,7 @@ The application is optimized for minimal resource usage:
 
 - Efficient tokio runtime configuration
 - Memory-optimized data structures
-- Connection pooling and reuse
+- Direct OKX public ticker WebSocket subscriptions
 - Configurable buffer sizes
 - Release build optimizations (LTO, strip symbols)
 
@@ -115,8 +115,8 @@ Set the `RUST_LOG` environment variable to control logging levels:
 # Debug logging
 RUST_LOG=debug cargo run
 
-# Exchange-specific logging
-RUST_LOG=exc_okx=debug,okx_streams=debug cargo run
+# App-specific logging
+RUST_LOG=okk=debug cargo run
 ```
 
 ## License

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -29,6 +29,7 @@
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{SyncSender, TrySendError};
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
@@ -63,174 +64,58 @@ impl ExchangeClient {
             self.config.trading_pairs.len()
         );
 
-        // Pre-allocate vector with known capacity to avoid reallocations
-        let mut handles = Vec::with_capacity(self.config.trading_pairs.len());
-
-        for pair in &self.config.trading_pairs {
-            let tx = tx.clone();
-            let pair = pair.clone(); // Clone only once per iteration
-            let update_interval = Duration::from_secs(self.config.update_interval_secs);
-            let connection_timeout = Duration::from_secs(self.config.ws_connection_timeout_secs);
-            let ping_timeout = Duration::from_secs(self.config.ws_ping_timeout_secs.max(1));
-
-            let handle = tokio::spawn(async move {
-                Self::monitor_pair(tx, pair, update_interval, connection_timeout, ping_timeout)
-                    .await;
-            });
-
-            handles.push(handle);
+        if self.config.trading_pairs.is_empty() {
+            return Ok(Vec::new());
         }
 
-        tracing::info!("Started {} monitoring tasks", handles.len());
-        Ok(handles)
+        let pairs = self.config.trading_pairs.clone();
+        let update_interval = Duration::from_secs(self.config.update_interval_secs);
+        let connection_timeout = Duration::from_secs(self.config.ws_connection_timeout_secs.max(1));
+        let pong_timeout = Duration::from_secs(self.config.ws_ping_timeout_secs.max(1));
+        let handle = tokio::spawn(async move {
+            Self::monitor_pairs(tx, pairs, update_interval, connection_timeout, pong_timeout).await;
+        });
+
+        tracing::info!("Started one shared OKX monitoring task");
+        Ok(vec![handle])
     }
 
-    /// Monitor a single trading pair with automatic reconnection and error recovery
-    async fn monitor_pair(
+    /// Monitor all configured pairs over one OKX connection.
+    async fn monitor_pairs(
         tx: SyncSender<PriceUpdate>,
-        pair: String,
+        pairs: Vec<String>,
         update_interval: Duration,
         connection_timeout: Duration,
-        ping_timeout: Duration,
+        pong_timeout: Duration,
     ) {
-        let mut consecutive_errors = 0;
-        let mut last_sent_at = None;
-        const MAX_CONSECUTIVE_ERRORS: u32 = 5;
+        let mut consecutive_errors = 0_u32;
+        let mut last_sent_at = HashMap::<String, Instant>::new();
         const BASE_BACKOFF_SECS: u64 = 1;
 
         loop {
-            tracing::info!("Starting monitoring for {}", pair);
+            tracing::info!("Connecting to OKX for {} pairs", pairs.len());
+            let result = Self::run_connection(
+                &tx,
+                &pairs,
+                &mut last_sent_at,
+                &mut consecutive_errors,
+                update_interval,
+                connection_timeout,
+                pong_timeout,
+            )
+            .await;
 
-            match tokio::time::timeout(connection_timeout, connect_async(OKX_PUBLIC_WS_URL)).await {
-                Ok(Ok((stream, _response))) => {
-                    consecutive_errors = 0; // Reset error counter on successful connection
-                    tracing::info!("Successfully connected to {} stream", pair);
-
-                    let (mut write, mut read) = stream.split();
-                    let subscribe_request = match build_okx_subscribe_request(&pair) {
-                        Ok(request) => request,
-                        Err(err) => {
-                            tracing::error!(
-                                "Failed to build OKX subscription for {}: {}",
-                                pair,
-                                err
-                            );
-                            return;
-                        }
-                    };
-
-                    if let Err(err) = write.send(Message::Text(subscribe_request.into())).await {
-                        consecutive_errors += 1;
-                        tracing::warn!("Failed to subscribe to {}: {}", pair, err);
-                    } else {
-                        tracing::info!("Subscribed to OKX ticker stream for {}", pair);
-                        let mut ping_interval = tokio::time::interval(ping_timeout);
-
-                        loop {
-                            tokio::select! {
-                                _ = ping_interval.tick() => {
-                                    if let Err(err) = write.send(Message::Text(OKX_PING.into())).await {
-                                        tracing::warn!("Failed to send OKX ping for {}: {}", pair, err);
-                                        break;
-                                    }
-                                }
-                                result = read.next() => {
-                                    match result {
-                                        Some(Ok(message)) => {
-                                            match message {
-                                                Message::Text(raw) => {
-                                                    let raw = raw.to_string();
-                                                    match parse_okx_ticker_updates(&raw) {
-                                                        Ok(updates) => {
-                                                            for ticker in updates {
-                                                                let now = Instant::now();
-                                                                if !should_emit_update(last_sent_at, now, update_interval) {
-                                                                    continue;
-                                                                }
-
-                                                                tracing::debug!("{}: {}", ticker.pair, ticker.last);
-
-                                                                match tx.try_send(PriceUpdate::new(ticker.pair, ticker.last)) {
-                                                                    Ok(()) => {
-                                                                        last_sent_at = Some(now);
-                                                                    }
-                                                                    Err(TrySendError::Full(_)) => {
-                                                                        tracing::warn!(
-                                                                            "Price update buffer full for {}, dropping stale update",
-                                                                            pair
-                                                                        );
-                                                                    }
-                                                                    Err(TrySendError::Disconnected(_)) => {
-                                                                        tracing::error!(
-                                                                            "Channel closed, stopping monitoring for {}",
-                                                                            pair
-                                                                        );
-                                                                        return; // Exit if channel is closed
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                        Err(err) => {
-                                                            tracing::warn!("Failed to parse OKX ticker message for {}: {}", pair, err);
-                                                            break;
-                                                        }
-                                                    }
-                                                }
-                                                Message::Ping(payload) => {
-                                                    if let Err(err) = write.send(Message::Pong(payload)).await {
-                                                        tracing::warn!("Failed to answer OKX ping for {}: {}", pair, err);
-                                                        break;
-                                                    }
-                                                }
-                                                Message::Pong(_) | Message::Binary(_) | Message::Frame(_) => {}
-                                                Message::Close(frame) => {
-                                                    tracing::warn!("OKX stream for {} closed: {:?}", pair, frame);
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                        Some(Err(err)) => {
-                                            tracing::warn!("Stream error for {}: {}", pair, err);
-                                            break; // Break inner loop to reconnect
-                                        }
-                                        None => {
-                                            tracing::warn!("Stream for {} ended, attempting reconnection...", pair);
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                Ok(Err(err)) => {
-                    consecutive_errors += 1;
-                    tracing::error!(
-                        "Failed to connect to OKX for {} (attempt {}/{}): {}",
-                        pair,
-                        consecutive_errors,
-                        MAX_CONSECUTIVE_ERRORS,
-                        err
-                    );
-                }
-                Err(_elapsed) => {
-                    consecutive_errors += 1;
-                    tracing::error!(
-                        "Timed out connecting to OKX for {} (attempt {}/{})",
-                        pair,
-                        consecutive_errors,
-                        MAX_CONSECUTIVE_ERRORS
-                    );
-                }
+            if matches!(result, Err(TickerError::ChannelError(_))) {
+                tracing::error!("Price update channel closed; stopping OKX monitoring");
+                return;
             }
-
-            if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
-                tracing::error!(
-                    "Max consecutive errors reached for {}, backing off longer",
-                    pair
+            if let Err(err) = result {
+                consecutive_errors = consecutive_errors.saturating_add(1);
+                tracing::warn!(
+                    "OKX connection attempt {} failed: {}",
+                    consecutive_errors,
+                    err
                 );
-                tokio::time::sleep(Duration::from_secs(BASE_BACKOFF_SECS * 10)).await;
-                consecutive_errors = 0; // Reset after long backoff
             }
 
             // Exponential backoff with simple jitter
@@ -240,11 +125,135 @@ impl ExchangeClient {
             let sleep_duration = Duration::from_secs(backoff_secs + jitter);
 
             tracing::info!(
-                "Waiting {:?} before reconnecting to {}",
+                "Waiting {:?} before reconnecting to OKX",
                 sleep_duration,
-                pair
             );
             tokio::time::sleep(sleep_duration).await;
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_connection(
+        tx: &SyncSender<PriceUpdate>,
+        pairs: &[String],
+        last_sent_at: &mut HashMap<String, Instant>,
+        consecutive_errors: &mut u32,
+        update_interval: Duration,
+        connection_timeout: Duration,
+        pong_timeout: Duration,
+    ) -> Result<()> {
+        let (stream, _response) = tokio::time::timeout(
+            connection_timeout,
+            connect_async(OKX_PUBLIC_WS_URL),
+        )
+        .await
+        .map_err(|_| TickerError::NetworkError("Timed out connecting to OKX".to_string()))?
+        .map_err(|err| TickerError::NetworkError(format!("Failed to connect to OKX: {err}")))?;
+        let (mut write, mut read) = stream.split();
+
+        let subscribe_request = build_okx_subscribe_request(pairs)?;
+        write
+            .send(Message::Text(subscribe_request.into()))
+            .await
+            .map_err(|err| TickerError::NetworkError(format!("Failed to subscribe: {err}")))?;
+
+        let mut pending: HashSet<String> = pairs.iter().cloned().collect();
+        tokio::time::timeout(connection_timeout, async {
+            while !pending.is_empty() {
+                match read.next().await {
+                    Some(Ok(Message::Text(raw))) => {
+                        if raw == OKX_PONG {
+                            continue;
+                        }
+                        if let Some(pair) = parse_okx_subscription_ack(&raw)? {
+                            if !pending.remove(&pair) {
+                                return Err(TickerError::ExchangeError(format!(
+                                    "Unexpected OKX subscription acknowledgement for {pair}"
+                                )));
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Ping(payload))) => write
+                        .send(Message::Pong(payload))
+                        .await
+                        .map_err(|err| TickerError::NetworkError(err.to_string()))?,
+                    Some(Ok(Message::Close(frame))) => {
+                        return Err(TickerError::NetworkError(format!(
+                            "OKX closed before subscription confirmation: {frame:?}"
+                        )));
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(err)) => return Err(TickerError::NetworkError(err.to_string())),
+                    None => {
+                        return Err(TickerError::NetworkError(
+                            "OKX ended before subscription confirmation".to_string(),
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|_| {
+            TickerError::NetworkError("Timed out waiting for OKX subscription confirmation".to_string())
+        })??;
+
+        tracing::info!("OKX confirmed {} ticker subscriptions", pairs.len());
+        let mut ping_interval = tokio::time::interval(pong_timeout);
+        ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut awaiting_pong_since: Option<Instant> = None;
+
+        loop {
+            tokio::select! {
+                _ = ping_interval.tick() => {
+                    if awaiting_pong_since.is_some_and(|sent| sent.elapsed() >= pong_timeout) {
+                        return Err(TickerError::NetworkError("OKX pong deadline exceeded".to_string()));
+                    }
+                    if awaiting_pong_since.is_none() {
+                        write.send(Message::Text(OKX_PING.into())).await
+                            .map_err(|err| TickerError::NetworkError(format!("Failed to ping OKX: {err}")))?;
+                        awaiting_pong_since = Some(Instant::now());
+                    }
+                }
+                result = read.next() => match result {
+                    Some(Ok(Message::Text(raw))) => {
+                        if raw == OKX_PONG {
+                            awaiting_pong_since = None;
+                            continue;
+                        }
+                        let updates = parse_okx_ticker_updates(&raw)?;
+                        if !updates.is_empty() {
+                            *consecutive_errors = 0;
+                        }
+                        for ticker in updates {
+                            let now = Instant::now();
+                            if !should_emit_update(last_sent_at.get(&ticker.pair).copied(), now, update_interval) {
+                                continue;
+                            }
+                            let pair = ticker.pair.clone();
+                            match tx.try_send(PriceUpdate::new(ticker.pair, ticker.last)) {
+                                Ok(()) => {
+                                    last_sent_at.insert(pair, now);
+                                }
+                                Err(TrySendError::Full(_)) => tracing::warn!(
+                                    "Price update buffer full for {pair}, dropping stale update"
+                                ),
+                                Err(TrySendError::Disconnected(_)) => return Err(
+                                    TickerError::ChannelError("Price update receiver closed".to_string())
+                                ),
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Ping(payload))) => write.send(Message::Pong(payload)).await
+                        .map_err(|err| TickerError::NetworkError(err.to_string()))?,
+                    Some(Ok(Message::Close(frame))) => return Err(TickerError::NetworkError(
+                        format!("OKX stream closed: {frame:?}")
+                    )),
+                    Some(Ok(Message::Pong(_) | Message::Binary(_) | Message::Frame(_))) => {}
+                    Some(Err(err)) => return Err(TickerError::NetworkError(err.to_string())),
+                    None => return Err(TickerError::NetworkError("OKX stream ended".to_string())),
+                }
+            }
         }
     }
 }
@@ -252,7 +261,7 @@ impl ExchangeClient {
 #[derive(Debug, Serialize)]
 struct OkxSubscribeRequest<'a> {
     op: &'static str,
-    args: [OkxSubscribeArg<'a>; 1],
+    args: Vec<OkxSubscribeArg<'a>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -267,7 +276,15 @@ struct OkxTickerPayload {
     event: Option<String>,
     code: Option<String>,
     msg: Option<String>,
+    arg: Option<OkxResponseArg>,
     data: Option<Vec<OkxTickerData>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OkxResponseArg {
+    channel: String,
+    #[serde(rename = "instId")]
+    inst_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -283,18 +300,50 @@ struct OkxTicker {
     last: Price,
 }
 
-fn build_okx_subscribe_request(pair: &str) -> Result<String> {
+fn build_okx_subscribe_request(pairs: &[String]) -> Result<String> {
     let request = OkxSubscribeRequest {
         op: "subscribe",
-        args: [OkxSubscribeArg {
-            channel: OKX_TICKERS_CHANNEL,
-            inst_id: pair,
-        }],
+        args: pairs
+            .iter()
+            .map(|pair| OkxSubscribeArg {
+                channel: OKX_TICKERS_CHANNEL,
+                inst_id: pair,
+            })
+            .collect(),
     };
 
     serde_json::to_string(&request).map_err(|e| {
         TickerError::ExchangeError(format!("Failed to serialize OKX subscription: {}", e))
     })
+}
+
+fn parse_okx_subscription_ack(raw: &str) -> Result<Option<String>> {
+    let payload: OkxTickerPayload = serde_json::from_str(raw)
+        .map_err(|err| TickerError::ExchangeError(format!("Invalid OKX message: {err}")))?;
+    if payload.event.as_deref() == Some("error") {
+        return Err(okx_payload_error(payload));
+    }
+    if payload.event.as_deref() != Some("subscribe") {
+        return Ok(None);
+    }
+    let arg = payload.arg.ok_or_else(|| {
+        TickerError::ExchangeError("OKX subscription acknowledgement omitted arg".to_string())
+    })?;
+    if arg.channel != OKX_TICKERS_CHANNEL {
+        return Err(TickerError::ExchangeError(format!(
+            "OKX acknowledged unexpected channel {}",
+            arg.channel
+        )));
+    }
+    Ok(Some(arg.inst_id))
+}
+
+fn okx_payload_error(payload: OkxTickerPayload) -> TickerError {
+    let code = payload.code.unwrap_or_else(|| "unknown".to_string());
+    let msg = payload
+        .msg
+        .unwrap_or_else(|| "OKX WebSocket error".to_string());
+    TickerError::ExchangeError(format!("OKX WebSocket error {code}: {msg}"))
 }
 
 fn parse_okx_ticker_updates(raw: &str) -> Result<Vec<OkxTicker>> {
@@ -306,14 +355,7 @@ fn parse_okx_ticker_updates(raw: &str) -> Result<Vec<OkxTicker>> {
         .map_err(|e| TickerError::ExchangeError(format!("Invalid OKX message: {}", e)))?;
 
     if payload.event.as_deref() == Some("error") {
-        let code = payload.code.unwrap_or_else(|| "unknown".to_string());
-        let msg = payload
-            .msg
-            .unwrap_or_else(|| "OKX WebSocket error".to_string());
-        return Err(TickerError::ExchangeError(format!(
-            "OKX WebSocket error {}: {}",
-            code, msg
-        )));
+        return Err(okx_payload_error(payload));
     }
 
     payload
@@ -520,7 +562,10 @@ mod tests {
 
     #[test]
     fn okx_subscription_request_uses_tickers_channel_and_inst_id() {
-        let request = match build_okx_subscribe_request("BTC-USDT") {
+        let request = match build_okx_subscribe_request(&[
+            "BTC-USDT".to_string(),
+            "ETH-USDT".to_string(),
+        ]) {
             Ok(request) => request,
             Err(e) => panic!("subscription request should serialize: {e}"),
         };
@@ -537,6 +582,10 @@ mod tests {
                     {
                         "channel": "tickers",
                         "instId": "BTC-USDT"
+                    },
+                    {
+                        "channel": "tickers",
+                        "instId": "ETH-USDT"
                     }
                 ]
             })
@@ -595,6 +644,25 @@ mod tests {
         };
 
         assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn okx_subscription_ack_validates_pair_and_channel() {
+        let pair = parse_okx_subscription_ack(
+            r#"{
+                "event": "subscribe",
+                "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+                "connId": "a4d3ae55"
+            }"#,
+        )
+        .expect("valid acknowledgement");
+        assert_eq!(pair.as_deref(), Some("BTC-USDT"));
+
+        let error = parse_okx_subscription_ack(
+            r#"{"event":"subscribe","arg":{"channel":"books","instId":"BTC-USDT"}}"#,
+        )
+        .expect_err("unexpected channel must fail");
+        assert!(error.to_string().contains("unexpected channel"));
     }
 
     #[test]

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -9,11 +9,10 @@
 //! - Support for multiple trading pairs simultaneously
 //! - Configurable connection timeouts and ping intervals
 //! - Structured price update events with timestamps
-//! - Built on the `exc` crate for exchange connectivity
+//! - Direct OKX public WebSocket integration
 //!
 //! ## Supported Exchanges
-//! - OKX (primary implementation)
-//! - Extensible architecture for additional exchanges
+//! - OKX public ticker channel
 //!
 //! ## Usage
 //! ```rust
@@ -27,16 +26,21 @@
 //! // let handles = client.start_price_monitoring(tx).await?;
 //! ```
 
-use chrono;
-use exc::prelude::*;
+use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::sync::mpsc::{SyncSender, TrySendError};
 use std::time::{Duration, Instant};
+use tokio::task::JoinHandle;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 use crate::config::Config;
-use crate::error::Result;
-use futures::StreamExt;
-use rust_decimal::Decimal;
-use tokio::task::JoinHandle;
+use crate::error::{Result, TickerError};
+
+const OKX_PUBLIC_WS_URL: &str = "wss://ws.okx.com:8443/ws/v5/public";
+const OKX_TICKERS_CHANNEL: &str = "tickers";
+const OKX_PING: &str = "ping";
+const OKX_PONG: &str = "pong";
 
 /// Exchange client wrapper for handling cryptocurrency price streams
 pub struct ExchangeClient {
@@ -59,23 +63,19 @@ impl ExchangeClient {
             self.config.trading_pairs.len()
         );
 
-        // Create a single exchange connection to be shared across all pairs
-        let exchange = Okx::endpoint()
-            .ws_ping_timeout(Duration::from_secs(self.config.ws_ping_timeout_secs))
-            .ws_connection_timeout(Duration::from_secs(self.config.ws_connection_timeout_secs))
-            .connect_exc();
-
         // Pre-allocate vector with known capacity to avoid reallocations
         let mut handles = Vec::with_capacity(self.config.trading_pairs.len());
 
         for pair in &self.config.trading_pairs {
-            let client = exchange.clone();
             let tx = tx.clone();
             let pair = pair.clone(); // Clone only once per iteration
             let update_interval = Duration::from_secs(self.config.update_interval_secs);
+            let connection_timeout = Duration::from_secs(self.config.ws_connection_timeout_secs);
+            let ping_timeout = Duration::from_secs(self.config.ws_ping_timeout_secs.max(1));
 
             let handle = tokio::spawn(async move {
-                Self::monitor_pair(client, tx, pair, update_interval).await;
+                Self::monitor_pair(tx, pair, update_interval, connection_timeout, ping_timeout)
+                    .await;
             });
 
             handles.push(handle);
@@ -87,10 +87,11 @@ impl ExchangeClient {
 
     /// Monitor a single trading pair with automatic reconnection and error recovery
     async fn monitor_pair(
-        mut client: impl exc::SubscribeTickersService + Clone + Send + 'static,
         tx: SyncSender<PriceUpdate>,
         pair: String,
         update_interval: Duration,
+        connection_timeout: Duration,
+        ping_timeout: Duration,
     ) {
         let mut consecutive_errors = 0;
         let mut last_sent_at = None;
@@ -100,69 +101,136 @@ impl ExchangeClient {
         loop {
             tracing::info!("Starting monitoring for {}", pair);
 
-            match client.subscribe_tickers(&pair).await {
-                Ok(mut stream) => {
+            match tokio::time::timeout(connection_timeout, connect_async(OKX_PUBLIC_WS_URL)).await {
+                Ok(Ok((stream, _response))) => {
                     consecutive_errors = 0; // Reset error counter on successful connection
                     tracing::info!("Successfully connected to {} stream", pair);
 
-                    while let Some(result) = stream.next().await {
-                        match result {
-                            Ok(ticker) => {
-                                let now = Instant::now();
-                                if !should_emit_update(last_sent_at, now, update_interval) {
-                                    continue;
-                                }
+                    let (mut write, mut read) = stream.split();
+                    let subscribe_request = match build_okx_subscribe_request(&pair) {
+                        Ok(request) => request,
+                        Err(err) => {
+                            tracing::error!(
+                                "Failed to build OKX subscription for {}: {}",
+                                pair,
+                                err
+                            );
+                            return;
+                        }
+                    };
 
-                                let update = PriceUpdate::new(pair.clone(), ticker.last);
+                    if let Err(err) = write.send(Message::Text(subscribe_request.into())).await {
+                        consecutive_errors += 1;
+                        tracing::warn!("Failed to subscribe to {}: {}", pair, err);
+                    } else {
+                        tracing::info!("Subscribed to OKX ticker stream for {}", pair);
+                        let mut ping_interval = tokio::time::interval(ping_timeout);
 
-                                tracing::debug!("{}: {}", pair, ticker.last);
-
-                                match tx.try_send(update) {
-                                    Ok(()) => {
-                                        last_sent_at = Some(now);
-                                    }
-                                    Err(TrySendError::Full(_)) => {
-                                        tracing::warn!(
-                                            "Price update buffer full for {}, dropping stale update",
-                                            pair
-                                        );
-                                    }
-                                    Err(TrySendError::Disconnected(_)) => {
-                                        tracing::error!(
-                                            "Channel closed, stopping monitoring for {}",
-                                            pair
-                                        );
-                                        return; // Exit if channel is closed
+                        loop {
+                            tokio::select! {
+                                _ = ping_interval.tick() => {
+                                    if let Err(err) = write.send(Message::Text(OKX_PING.into())).await {
+                                        tracing::warn!("Failed to send OKX ping for {}: {}", pair, err);
+                                        break;
                                     }
                                 }
-                            }
-                            Err(err) => {
-                                tracing::warn!("Stream error for {}: {}", pair, err);
-                                break; // Break inner loop to reconnect
+                                result = read.next() => {
+                                    match result {
+                                        Some(Ok(message)) => {
+                                            match message {
+                                                Message::Text(raw) => {
+                                                    let raw = raw.to_string();
+                                                    match parse_okx_ticker_updates(&raw) {
+                                                        Ok(updates) => {
+                                                            for ticker in updates {
+                                                                let now = Instant::now();
+                                                                if !should_emit_update(last_sent_at, now, update_interval) {
+                                                                    continue;
+                                                                }
+
+                                                                tracing::debug!("{}: {}", ticker.pair, ticker.last);
+
+                                                                match tx.try_send(PriceUpdate::new(ticker.pair, ticker.last)) {
+                                                                    Ok(()) => {
+                                                                        last_sent_at = Some(now);
+                                                                    }
+                                                                    Err(TrySendError::Full(_)) => {
+                                                                        tracing::warn!(
+                                                                            "Price update buffer full for {}, dropping stale update",
+                                                                            pair
+                                                                        );
+                                                                    }
+                                                                    Err(TrySendError::Disconnected(_)) => {
+                                                                        tracing::error!(
+                                                                            "Channel closed, stopping monitoring for {}",
+                                                                            pair
+                                                                        );
+                                                                        return; // Exit if channel is closed
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                        Err(err) => {
+                                                            tracing::warn!("Failed to parse OKX ticker message for {}: {}", pair, err);
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+                                                Message::Ping(payload) => {
+                                                    if let Err(err) = write.send(Message::Pong(payload)).await {
+                                                        tracing::warn!("Failed to answer OKX ping for {}: {}", pair, err);
+                                                        break;
+                                                    }
+                                                }
+                                                Message::Pong(_) | Message::Binary(_) | Message::Frame(_) => {}
+                                                Message::Close(frame) => {
+                                                    tracing::warn!("OKX stream for {} closed: {:?}", pair, frame);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        Some(Err(err)) => {
+                                            tracing::warn!("Stream error for {}: {}", pair, err);
+                                            break; // Break inner loop to reconnect
+                                        }
+                                        None => {
+                                            tracing::warn!("Stream for {} ended, attempting reconnection...", pair);
+                                            break;
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
-                    tracing::warn!("Stream for {} ended, attempting reconnection...", pair);
                 }
-                Err(err) => {
+                Ok(Err(err)) => {
                     consecutive_errors += 1;
                     tracing::error!(
-                        "Failed to subscribe to {} (attempt {}/{}): {}",
+                        "Failed to connect to OKX for {} (attempt {}/{}): {}",
                         pair,
                         consecutive_errors,
                         MAX_CONSECUTIVE_ERRORS,
                         err
                     );
-
-                    if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
-                        tracing::error!(
-                            "Max consecutive errors reached for {}, backing off longer",
-                            pair
-                        );
-                        tokio::time::sleep(Duration::from_secs(BASE_BACKOFF_SECS * 10)).await;
-                        consecutive_errors = 0; // Reset after long backoff
-                    }
                 }
+                Err(_elapsed) => {
+                    consecutive_errors += 1;
+                    tracing::error!(
+                        "Timed out connecting to OKX for {} (attempt {}/{})",
+                        pair,
+                        consecutive_errors,
+                        MAX_CONSECUTIVE_ERRORS
+                    );
+                }
+            }
+
+            if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                tracing::error!(
+                    "Max consecutive errors reached for {}, backing off longer",
+                    pair
+                );
+                tokio::time::sleep(Duration::from_secs(BASE_BACKOFF_SECS * 10)).await;
+                consecutive_errors = 0; // Reset after long backoff
             }
 
             // Exponential backoff with simple jitter
@@ -181,6 +249,93 @@ impl ExchangeClient {
     }
 }
 
+#[derive(Debug, Serialize)]
+struct OkxSubscribeRequest<'a> {
+    op: &'static str,
+    args: [OkxSubscribeArg<'a>; 1],
+}
+
+#[derive(Debug, Serialize)]
+struct OkxSubscribeArg<'a> {
+    channel: &'static str,
+    #[serde(rename = "instId")]
+    inst_id: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct OkxTickerPayload {
+    event: Option<String>,
+    code: Option<String>,
+    msg: Option<String>,
+    data: Option<Vec<OkxTickerData>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OkxTickerData {
+    #[serde(rename = "instId")]
+    inst_id: String,
+    last: String,
+}
+
+#[derive(Debug, PartialEq)]
+struct OkxTicker {
+    pair: String,
+    last: Price,
+}
+
+fn build_okx_subscribe_request(pair: &str) -> Result<String> {
+    let request = OkxSubscribeRequest {
+        op: "subscribe",
+        args: [OkxSubscribeArg {
+            channel: OKX_TICKERS_CHANNEL,
+            inst_id: pair,
+        }],
+    };
+
+    serde_json::to_string(&request).map_err(|e| {
+        TickerError::ExchangeError(format!("Failed to serialize OKX subscription: {}", e))
+    })
+}
+
+fn parse_okx_ticker_updates(raw: &str) -> Result<Vec<OkxTicker>> {
+    if raw == OKX_PONG || raw.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let payload: OkxTickerPayload = serde_json::from_str(raw)
+        .map_err(|e| TickerError::ExchangeError(format!("Invalid OKX message: {}", e)))?;
+
+    if payload.event.as_deref() == Some("error") {
+        let code = payload.code.unwrap_or_else(|| "unknown".to_string());
+        let msg = payload
+            .msg
+            .unwrap_or_else(|| "OKX WebSocket error".to_string());
+        return Err(TickerError::ExchangeError(format!(
+            "OKX WebSocket error {}: {}",
+            code, msg
+        )));
+    }
+
+    payload
+        .data
+        .unwrap_or_default()
+        .into_iter()
+        .map(|ticker| {
+            let last = Price::parse(&ticker.last).map_err(|_e| {
+                TickerError::ExchangeError(format!(
+                    "Invalid OKX ticker price for {}: {}",
+                    ticker.inst_id, ticker.last
+                ))
+            })?;
+
+            Ok(OkxTicker {
+                pair: ticker.inst_id,
+                last,
+            })
+        })
+        .collect()
+}
+
 fn should_emit_update(
     last_sent_at: Option<Instant>,
     now: Instant,
@@ -192,13 +347,136 @@ fn should_emit_update(
     }
 }
 
+/// Price text received from an exchange, validated as a decimal number.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Price {
+    raw: String,
+}
+
+impl Price {
+    /// Parse a decimal price string from an exchange payload.
+    pub fn parse(raw: &str) -> Result<Self> {
+        if !is_valid_decimal(raw) {
+            return Err(TickerError::ExchangeError(format!(
+                "Invalid price: {}",
+                raw
+            )));
+        }
+
+        Ok(Self {
+            raw: raw.to_string(),
+        })
+    }
+
+    /// Return the exact price text received from the exchange.
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    /// Format the price with a fixed number of fractional digits.
+    pub fn format_with_precision(&self, precision: usize) -> String {
+        format_decimal_with_precision(&self.raw, precision)
+    }
+}
+
+impl fmt::Display for Price {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+fn is_valid_decimal(raw: &str) -> bool {
+    if raw.trim() != raw {
+        return false;
+    }
+
+    let unsigned = raw.strip_prefix('-').unwrap_or(raw);
+    if unsigned.is_empty() {
+        return false;
+    }
+
+    let mut parts = unsigned.split('.');
+    let whole = parts.next().unwrap_or_default();
+    let fraction = parts.next();
+
+    if parts.next().is_some() || whole.is_empty() || !whole.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+
+    match fraction {
+        Some(fraction) => !fraction.is_empty() && fraction.bytes().all(|b| b.is_ascii_digit()),
+        None => true,
+    }
+}
+
+fn format_decimal_with_precision(raw: &str, precision: usize) -> String {
+    let (sign, unsigned) = match raw.strip_prefix('-') {
+        Some(unsigned) => ("-", unsigned),
+        None => ("", raw),
+    };
+    let (whole, fraction) = unsigned.split_once('.').unwrap_or((unsigned, ""));
+    let mut whole_digits = normalized_integer_digits(whole).into_bytes();
+    let mut fraction_digits = vec![b'0'; precision];
+
+    for (index, digit) in fraction.bytes().take(precision).enumerate() {
+        fraction_digits[index] = digit;
+    }
+
+    if fraction
+        .as_bytes()
+        .get(precision)
+        .is_some_and(|digit| *digit >= b'5')
+    {
+        increment_fixed_decimal(&mut whole_digits, &mut fraction_digits);
+    }
+
+    let whole = String::from_utf8(whole_digits).unwrap_or_else(|_| "0".to_string());
+    if precision == 0 {
+        return format!("{sign}{whole}");
+    }
+
+    let fraction = String::from_utf8(fraction_digits).unwrap_or_default();
+    format!("{sign}{whole}.{fraction}")
+}
+
+fn normalized_integer_digits(whole: &str) -> String {
+    let trimmed = whole.trim_start_matches('0');
+    if trimmed.is_empty() {
+        "0".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn increment_fixed_decimal(whole_digits: &mut Vec<u8>, fraction_digits: &mut [u8]) {
+    for digit in fraction_digits.iter_mut().rev() {
+        if *digit == b'9' {
+            *digit = b'0';
+        } else {
+            *digit += 1;
+            return;
+        }
+    }
+
+    for digit in whole_digits.iter_mut().rev() {
+        if *digit == b'9' {
+            *digit = b'0';
+        } else {
+            *digit += 1;
+            return;
+        }
+    }
+
+    whole_digits.insert(0, b'1');
+}
+
 /// Price update information optimized for memory efficiency
 #[derive(Debug, Clone)]
 pub struct PriceUpdate {
     /// Trading pair symbol (e.g., "BTC-USDT")
     pub pair: String,
-    /// Current price as decimal
-    pub price: Decimal,
+    /// Current price received from the exchange
+    pub price: Price,
     /// Unix timestamp in milliseconds for better performance
     pub timestamp_ms: i64,
 }
@@ -239,11 +517,113 @@ mod tests {
             Duration::from_secs(10)
         ));
     }
+
+    #[test]
+    fn okx_subscription_request_uses_tickers_channel_and_inst_id() {
+        let request = match build_okx_subscribe_request("BTC-USDT") {
+            Ok(request) => request,
+            Err(e) => panic!("subscription request should serialize: {e}"),
+        };
+        let request: serde_json::Value = match serde_json::from_str(&request) {
+            Ok(request) => request,
+            Err(e) => panic!("subscription request should be JSON: {e}"),
+        };
+
+        assert_eq!(
+            request,
+            serde_json::json!({
+                "op": "subscribe",
+                "args": [
+                    {
+                        "channel": "tickers",
+                        "instId": "BTC-USDT"
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn price_formats_with_fixed_precision() {
+        let price = match Price::parse("9999.999") {
+            Ok(price) => price,
+            Err(e) => panic!("price should parse: {e}"),
+        };
+
+        assert_eq!(price.format_with_precision(2), "10000.00");
+    }
+
+    #[test]
+    fn okx_ticker_message_converts_last_price_to_price() {
+        let updates = match parse_okx_ticker_updates(
+            r#"{
+                "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+                "data": [
+                    {
+                        "instType": "SPOT",
+                        "instId": "BTC-USDT",
+                        "last": "9999.99",
+                        "ts": "1597026383085"
+                    }
+                ]
+            }"#,
+        ) {
+            Ok(updates) => updates,
+            Err(e) => panic!("ticker message should parse: {e}"),
+        };
+
+        assert_eq!(
+            updates,
+            vec![OkxTicker {
+                pair: "BTC-USDT".to_string(),
+                last: price("9999.99"),
+            }]
+        );
+    }
+
+    #[test]
+    fn okx_subscription_ack_is_ignored() {
+        let updates = match parse_okx_ticker_updates(
+            r#"{
+                "event": "subscribe",
+                "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+                "connId": "a4d3ae55"
+            }"#,
+        ) {
+            Ok(updates) => updates,
+            Err(e) => panic!("subscription acknowledgement should parse: {e}"),
+        };
+
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn okx_error_event_reports_exchange_error() {
+        let error = match parse_okx_ticker_updates(
+            r#"{
+                "event": "error",
+                "code": "60012",
+                "msg": "Invalid request"
+            }"#,
+        ) {
+            Ok(_) => panic!("error event should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("OKX WebSocket error 60012"));
+    }
+
+    fn price(raw: &str) -> Price {
+        match Price::parse(raw) {
+            Ok(price) => price,
+            Err(e) => panic!("price should parse: {e}"),
+        }
+    }
 }
 
 impl PriceUpdate {
     /// Create a new price update with current timestamp
-    pub fn new(pair: String, price: Decimal) -> Self {
+    pub fn new(pair: String, price: Price) -> Self {
         Self {
             pair,
             price,

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -28,8 +28,8 @@
 
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::sync::mpsc::{SyncSender, TrySendError};
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
@@ -124,10 +124,7 @@ impl ExchangeClient {
                 (chrono::Utc::now().timestamp_millis() % (backoff_secs as i64 / 2 + 1)) as u64;
             let sleep_duration = Duration::from_secs(backoff_secs + jitter);
 
-            tracing::info!(
-                "Waiting {:?} before reconnecting to OKX",
-                sleep_duration,
-            );
+            tracing::info!("Waiting {:?} before reconnecting to OKX", sleep_duration,);
             tokio::time::sleep(sleep_duration).await;
         }
     }
@@ -142,35 +139,50 @@ impl ExchangeClient {
         connection_timeout: Duration,
         pong_timeout: Duration,
     ) -> Result<()> {
-        let (stream, _response) = tokio::time::timeout(
-            connection_timeout,
-            connect_async(OKX_PUBLIC_WS_URL),
-        )
-        .await
-        .map_err(|_| TickerError::NetworkError("Timed out connecting to OKX".to_string()))?
-        .map_err(|err| TickerError::NetworkError(format!("Failed to connect to OKX: {err}")))?;
+        let (stream, _response) =
+            tokio::time::timeout(connection_timeout, connect_async(OKX_PUBLIC_WS_URL))
+                .await
+                .map_err(|_| TickerError::NetworkError("Timed out connecting to OKX".to_string()))?
+                .map_err(|err| {
+                    TickerError::NetworkError(format!("Failed to connect to OKX: {err}"))
+                })?;
         let (mut write, mut read) = stream.split();
 
-        let subscribe_request = build_okx_subscribe_request(pairs)?;
-        write
-            .send(Message::Text(subscribe_request.into()))
-            .await
-            .map_err(|err| TickerError::NetworkError(format!("Failed to subscribe: {err}")))?;
+        let mut pending = HashMap::<String, String>::new();
+        for (index, pair) in pairs.iter().enumerate() {
+            let request_id = format!("ticker-{index}");
+            let subscribe_request = build_okx_subscribe_request(&request_id, pair)?;
+            write
+                .send(Message::Text(subscribe_request.into()))
+                .await
+                .map_err(|err| {
+                    TickerError::NetworkError(format!("Failed to subscribe to {pair}: {err}"))
+                })?;
+            pending.insert(request_id, pair.clone());
+        }
 
-        let mut pending: HashSet<String> = pairs.iter().cloned().collect();
-        tokio::time::timeout(connection_timeout, async {
+        let mut active_pairs = HashSet::<String>::new();
+        let confirmation_result = tokio::time::timeout(connection_timeout, async {
             while !pending.is_empty() {
                 match read.next().await {
                     Some(Ok(Message::Text(raw))) => {
-                        if raw == OKX_PONG {
-                            continue;
-                        }
-                        if let Some(pair) = parse_okx_subscription_ack(&raw)? {
-                            if !pending.remove(&pair) {
-                                return Err(TickerError::ExchangeError(format!(
-                                    "Unexpected OKX subscription acknowledgement for {pair}"
-                                )));
+                        match classify_subscription_frame(&raw, &mut pending)? {
+                            OkxSubscriptionFrame::Acknowledged(pair) => {
+                                active_pairs.insert(pair);
                             }
+                            OkxSubscriptionFrame::Rejected { pair, error } => {
+                                tracing::warn!(
+                                    "OKX rejected ticker subscription for {pair}: {error}"
+                                );
+                            }
+                            OkxSubscriptionFrame::Updates(updates) => Self::emit_ticker_updates(
+                                tx,
+                                last_sent_at,
+                                consecutive_errors,
+                                update_interval,
+                                updates,
+                            )?,
+                            OkxSubscriptionFrame::Pong | OkxSubscriptionFrame::Other => {}
                         }
                     }
                     Some(Ok(Message::Ping(payload))) => write
@@ -193,12 +205,33 @@ impl ExchangeClient {
             }
             Ok(())
         })
-        .await
-        .map_err(|_| {
-            TickerError::NetworkError("Timed out waiting for OKX subscription confirmation".to_string())
-        })??;
+        .await;
 
-        tracing::info!("OKX confirmed {} ticker subscriptions", pairs.len());
+        match confirmation_result {
+            Ok(result) => result?,
+            Err(_) if active_pairs.is_empty() => {
+                return Err(TickerError::NetworkError(
+                    "Timed out waiting for any OKX subscription confirmation".to_string(),
+                ));
+            }
+            Err(_) => tracing::warn!(
+                "Timed out waiting for {} OKX subscription confirmations; keeping {} confirmed pairs active",
+                pending.len(),
+                active_pairs.len()
+            ),
+        }
+
+        if active_pairs.is_empty() {
+            return Err(TickerError::ExchangeError(
+                "OKX rejected all ticker subscriptions".to_string(),
+            ));
+        }
+
+        tracing::info!(
+            "OKX confirmed {} of {} ticker subscriptions",
+            active_pairs.len(),
+            pairs.len()
+        );
         let mut ping_interval = tokio::time::interval(pong_timeout);
         ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let mut awaiting_pong_since: Option<Instant> = None;
@@ -221,28 +254,29 @@ impl ExchangeClient {
                             awaiting_pong_since = None;
                             continue;
                         }
-                        let updates = parse_okx_ticker_updates(&raw)?;
-                        if !updates.is_empty() {
-                            *consecutive_errors = 0;
-                        }
-                        for ticker in updates {
-                            let now = Instant::now();
-                            if !should_emit_update(last_sent_at.get(&ticker.pair).copied(), now, update_interval) {
-                                continue;
-                            }
-                            let pair = ticker.pair.clone();
-                            match tx.try_send(PriceUpdate::new(ticker.pair, ticker.last)) {
-                                Ok(()) => {
-                                    last_sent_at.insert(pair, now);
+                        if let Some(response) = parse_okx_subscription_response(&raw)? {
+                            match response {
+                                OkxSubscriptionResponse::Acknowledged { request_id, pair } => {
+                                    tracing::debug!(
+                                        "Received late OKX subscription acknowledgement {request_id} for {pair}"
+                                    );
                                 }
-                                Err(TrySendError::Full(_)) => tracing::warn!(
-                                    "Price update buffer full for {pair}, dropping stale update"
-                                ),
-                                Err(TrySendError::Disconnected(_)) => return Err(
-                                    TickerError::ChannelError("Price update receiver closed".to_string())
-                                ),
+                                OkxSubscriptionResponse::Rejected { request_id, error } => {
+                                    tracing::warn!(
+                                        "OKX rejected subscription request {request_id}: {error}"
+                                    );
+                                }
                             }
+                            continue;
                         }
+                        let updates = parse_okx_ticker_updates(&raw)?;
+                        Self::emit_ticker_updates(
+                            tx,
+                            last_sent_at,
+                            consecutive_errors,
+                            update_interval,
+                            updates,
+                        )?;
                     }
                     Some(Ok(Message::Ping(payload))) => write.send(Message::Pong(payload)).await
                         .map_err(|err| TickerError::NetworkError(err.to_string()))?,
@@ -256,10 +290,48 @@ impl ExchangeClient {
             }
         }
     }
+
+    fn emit_ticker_updates(
+        tx: &SyncSender<PriceUpdate>,
+        last_sent_at: &mut HashMap<String, Instant>,
+        consecutive_errors: &mut u32,
+        update_interval: Duration,
+        updates: Vec<OkxTicker>,
+    ) -> Result<()> {
+        if !updates.is_empty() {
+            *consecutive_errors = 0;
+        }
+        for ticker in updates {
+            let now = Instant::now();
+            if !should_emit_update(
+                last_sent_at.get(&ticker.pair).copied(),
+                now,
+                update_interval,
+            ) {
+                continue;
+            }
+            let pair = ticker.pair.clone();
+            match tx.try_send(PriceUpdate::new(ticker.pair, ticker.last)) {
+                Ok(()) => {
+                    last_sent_at.insert(pair, now);
+                }
+                Err(TrySendError::Full(_)) => {
+                    tracing::warn!("Price update buffer full for {pair}, dropping stale update")
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    return Err(TickerError::ChannelError(
+                        "Price update receiver closed".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize)]
 struct OkxSubscribeRequest<'a> {
+    id: &'a str,
     op: &'static str,
     args: Vec<OkxSubscribeArg<'a>>,
 }
@@ -273,11 +345,12 @@ struct OkxSubscribeArg<'a> {
 
 #[derive(Debug, Deserialize)]
 struct OkxTickerPayload {
+    id: Option<String>,
     event: Option<String>,
     code: Option<String>,
     msg: Option<String>,
     arg: Option<OkxResponseArg>,
-    data: Option<Vec<OkxTickerData>>,
+    data: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -300,16 +373,29 @@ struct OkxTicker {
     last: Price,
 }
 
-fn build_okx_subscribe_request(pairs: &[String]) -> Result<String> {
+#[derive(Debug, PartialEq)]
+enum OkxSubscriptionResponse {
+    Acknowledged { request_id: String, pair: String },
+    Rejected { request_id: String, error: String },
+}
+
+#[derive(Debug, PartialEq)]
+enum OkxSubscriptionFrame {
+    Acknowledged(String),
+    Rejected { pair: String, error: String },
+    Updates(Vec<OkxTicker>),
+    Pong,
+    Other,
+}
+
+fn build_okx_subscribe_request(request_id: &str, pair: &str) -> Result<String> {
     let request = OkxSubscribeRequest {
+        id: request_id,
         op: "subscribe",
-        args: pairs
-            .iter()
-            .map(|pair| OkxSubscribeArg {
-                channel: OKX_TICKERS_CHANNEL,
-                inst_id: pair,
-            })
-            .collect(),
+        args: vec![OkxSubscribeArg {
+            channel: OKX_TICKERS_CHANNEL,
+            inst_id: pair,
+        }],
     };
 
     serde_json::to_string(&request).map_err(|e| {
@@ -317,15 +403,26 @@ fn build_okx_subscribe_request(pairs: &[String]) -> Result<String> {
     })
 }
 
-fn parse_okx_subscription_ack(raw: &str) -> Result<Option<String>> {
+fn parse_okx_subscription_response(raw: &str) -> Result<Option<OkxSubscriptionResponse>> {
     let payload: OkxTickerPayload = serde_json::from_str(raw)
         .map_err(|err| TickerError::ExchangeError(format!("Invalid OKX message: {err}")))?;
     if payload.event.as_deref() == Some("error") {
-        return Err(okx_payload_error(payload));
+        let request_id = payload.id.clone().ok_or_else(|| {
+            TickerError::ExchangeError("OKX subscription error omitted request id".to_string())
+        })?;
+        return Ok(Some(OkxSubscriptionResponse::Rejected {
+            request_id,
+            error: okx_payload_error(payload).to_string(),
+        }));
     }
     if payload.event.as_deref() != Some("subscribe") {
         return Ok(None);
     }
+    let request_id = payload.id.ok_or_else(|| {
+        TickerError::ExchangeError(
+            "OKX subscription acknowledgement omitted request id".to_string(),
+        )
+    })?;
     let arg = payload.arg.ok_or_else(|| {
         TickerError::ExchangeError("OKX subscription acknowledgement omitted arg".to_string())
     })?;
@@ -335,7 +432,51 @@ fn parse_okx_subscription_ack(raw: &str) -> Result<Option<String>> {
             arg.channel
         )));
     }
-    Ok(Some(arg.inst_id))
+    Ok(Some(OkxSubscriptionResponse::Acknowledged {
+        request_id,
+        pair: arg.inst_id,
+    }))
+}
+
+fn classify_subscription_frame(
+    raw: &str,
+    pending: &mut HashMap<String, String>,
+) -> Result<OkxSubscriptionFrame> {
+    if raw == OKX_PONG {
+        return Ok(OkxSubscriptionFrame::Pong);
+    }
+
+    match parse_okx_subscription_response(raw)? {
+        Some(OkxSubscriptionResponse::Acknowledged { request_id, pair }) => {
+            let expected_pair = pending.remove(&request_id).ok_or_else(|| {
+                TickerError::ExchangeError(format!(
+                    "Unexpected OKX subscription acknowledgement id {request_id}"
+                ))
+            })?;
+            if expected_pair != pair {
+                return Err(TickerError::ExchangeError(format!(
+                    "OKX subscription {request_id} acknowledged {pair} instead of {expected_pair}"
+                )));
+            }
+            Ok(OkxSubscriptionFrame::Acknowledged(pair))
+        }
+        Some(OkxSubscriptionResponse::Rejected { request_id, error }) => {
+            let pair = pending.remove(&request_id).ok_or_else(|| {
+                TickerError::ExchangeError(format!(
+                    "Unexpected OKX subscription error id {request_id}"
+                ))
+            })?;
+            Ok(OkxSubscriptionFrame::Rejected { pair, error })
+        }
+        None => {
+            let updates = parse_okx_ticker_updates(raw)?;
+            if updates.is_empty() {
+                Ok(OkxSubscriptionFrame::Other)
+            } else {
+                Ok(OkxSubscriptionFrame::Updates(updates))
+            }
+        }
+    }
 }
 
 fn okx_payload_error(payload: OkxTickerPayload) -> TickerError {
@@ -358,24 +499,38 @@ fn parse_okx_ticker_updates(raw: &str) -> Result<Vec<OkxTicker>> {
         return Err(okx_payload_error(payload));
     }
 
-    payload
+    let updates = payload
         .data
         .unwrap_or_default()
         .into_iter()
-        .map(|ticker| {
-            let last = Price::parse(&ticker.last).map_err(|_e| {
-                TickerError::ExchangeError(format!(
-                    "Invalid OKX ticker price for {}: {}",
-                    ticker.inst_id, ticker.last
-                ))
-            })?;
+        .filter_map(|value| {
+            let ticker = match serde_json::from_value::<OkxTickerData>(value) {
+                Ok(ticker) => ticker,
+                Err(err) => {
+                    tracing::warn!("Ignoring malformed OKX ticker item: {err}");
+                    return None;
+                }
+            };
+            let last = match Price::parse(&ticker.last) {
+                Ok(last) => last,
+                Err(err) => {
+                    tracing::warn!(
+                        "Ignoring invalid OKX ticker price for {}: {}",
+                        ticker.inst_id,
+                        err
+                    );
+                    return None;
+                }
+            };
 
-            Ok(OkxTicker {
+            Some(OkxTicker {
                 pair: ticker.inst_id,
                 last,
             })
         })
-        .collect()
+        .collect();
+
+    Ok(updates)
 }
 
 fn should_emit_update(
@@ -524,170 +679,7 @@ pub struct PriceUpdate {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn update_interval_allows_first_update() {
-        assert!(should_emit_update(
-            None,
-            Instant::now(),
-            Duration::from_secs(10)
-        ));
-    }
-
-    #[test]
-    fn update_interval_throttles_recent_update() {
-        let last_sent_at = Instant::now();
-        let now = last_sent_at + Duration::from_secs(1);
-
-        assert!(!should_emit_update(
-            Some(last_sent_at),
-            now,
-            Duration::from_secs(10)
-        ));
-    }
-
-    #[test]
-    fn update_interval_allows_elapsed_update() {
-        let last_sent_at = Instant::now();
-        let now = last_sent_at + Duration::from_secs(10);
-
-        assert!(should_emit_update(
-            Some(last_sent_at),
-            now,
-            Duration::from_secs(10)
-        ));
-    }
-
-    #[test]
-    fn okx_subscription_request_uses_tickers_channel_and_inst_id() {
-        let request = match build_okx_subscribe_request(&[
-            "BTC-USDT".to_string(),
-            "ETH-USDT".to_string(),
-        ]) {
-            Ok(request) => request,
-            Err(e) => panic!("subscription request should serialize: {e}"),
-        };
-        let request: serde_json::Value = match serde_json::from_str(&request) {
-            Ok(request) => request,
-            Err(e) => panic!("subscription request should be JSON: {e}"),
-        };
-
-        assert_eq!(
-            request,
-            serde_json::json!({
-                "op": "subscribe",
-                "args": [
-                    {
-                        "channel": "tickers",
-                        "instId": "BTC-USDT"
-                    },
-                    {
-                        "channel": "tickers",
-                        "instId": "ETH-USDT"
-                    }
-                ]
-            })
-        );
-    }
-
-    #[test]
-    fn price_formats_with_fixed_precision() {
-        let price = match Price::parse("9999.999") {
-            Ok(price) => price,
-            Err(e) => panic!("price should parse: {e}"),
-        };
-
-        assert_eq!(price.format_with_precision(2), "10000.00");
-    }
-
-    #[test]
-    fn okx_ticker_message_converts_last_price_to_price() {
-        let updates = match parse_okx_ticker_updates(
-            r#"{
-                "arg": {"channel": "tickers", "instId": "BTC-USDT"},
-                "data": [
-                    {
-                        "instType": "SPOT",
-                        "instId": "BTC-USDT",
-                        "last": "9999.99",
-                        "ts": "1597026383085"
-                    }
-                ]
-            }"#,
-        ) {
-            Ok(updates) => updates,
-            Err(e) => panic!("ticker message should parse: {e}"),
-        };
-
-        assert_eq!(
-            updates,
-            vec![OkxTicker {
-                pair: "BTC-USDT".to_string(),
-                last: price("9999.99"),
-            }]
-        );
-    }
-
-    #[test]
-    fn okx_subscription_ack_is_ignored() {
-        let updates = match parse_okx_ticker_updates(
-            r#"{
-                "event": "subscribe",
-                "arg": {"channel": "tickers", "instId": "BTC-USDT"},
-                "connId": "a4d3ae55"
-            }"#,
-        ) {
-            Ok(updates) => updates,
-            Err(e) => panic!("subscription acknowledgement should parse: {e}"),
-        };
-
-        assert!(updates.is_empty());
-    }
-
-    #[test]
-    fn okx_subscription_ack_validates_pair_and_channel() {
-        let pair = parse_okx_subscription_ack(
-            r#"{
-                "event": "subscribe",
-                "arg": {"channel": "tickers", "instId": "BTC-USDT"},
-                "connId": "a4d3ae55"
-            }"#,
-        )
-        .expect("valid acknowledgement");
-        assert_eq!(pair.as_deref(), Some("BTC-USDT"));
-
-        let error = parse_okx_subscription_ack(
-            r#"{"event":"subscribe","arg":{"channel":"books","instId":"BTC-USDT"}}"#,
-        )
-        .expect_err("unexpected channel must fail");
-        assert!(error.to_string().contains("unexpected channel"));
-    }
-
-    #[test]
-    fn okx_error_event_reports_exchange_error() {
-        let error = match parse_okx_ticker_updates(
-            r#"{
-                "event": "error",
-                "code": "60012",
-                "msg": "Invalid request"
-            }"#,
-        ) {
-            Ok(_) => panic!("error event should fail"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("OKX WebSocket error 60012"));
-    }
-
-    fn price(raw: &str) -> Price {
-        match Price::parse(raw) {
-            Ok(price) => price,
-            Err(e) => panic!("price should parse: {e}"),
-        }
-    }
-}
+mod tests;
 
 impl PriceUpdate {
     /// Create a new price update with current timestamp

--- a/src/exchange/tests.rs
+++ b/src/exchange/tests.rs
@@ -1,0 +1,241 @@
+use super::*;
+
+#[test]
+fn update_interval_allows_first_update() {
+    assert!(should_emit_update(
+        None,
+        Instant::now(),
+        Duration::from_secs(10)
+    ));
+}
+
+#[test]
+fn update_interval_throttles_recent_update() {
+    let last_sent_at = Instant::now();
+    let now = last_sent_at + Duration::from_secs(1);
+
+    assert!(!should_emit_update(
+        Some(last_sent_at),
+        now,
+        Duration::from_secs(10)
+    ));
+}
+
+#[test]
+fn update_interval_allows_elapsed_update() {
+    let last_sent_at = Instant::now();
+    let now = last_sent_at + Duration::from_secs(10);
+
+    assert!(should_emit_update(
+        Some(last_sent_at),
+        now,
+        Duration::from_secs(10)
+    ));
+}
+
+#[test]
+fn okx_subscription_request_uses_tickers_channel_and_inst_id() {
+    let request = match build_okx_subscribe_request("ticker-0", "BTC-USDT") {
+        Ok(request) => request,
+        Err(e) => panic!("subscription request should serialize: {e}"),
+    };
+    let request: serde_json::Value = match serde_json::from_str(&request) {
+        Ok(request) => request,
+        Err(e) => panic!("subscription request should be JSON: {e}"),
+    };
+
+    assert_eq!(
+        request,
+        serde_json::json!({
+            "id": "ticker-0",
+            "op": "subscribe",
+            "args": [
+                {
+                    "channel": "tickers",
+                    "instId": "BTC-USDT"
+                }
+            ]
+        })
+    );
+}
+
+#[test]
+fn price_formats_with_fixed_precision() {
+    let price = match Price::parse("9999.999") {
+        Ok(price) => price,
+        Err(e) => panic!("price should parse: {e}"),
+    };
+
+    assert_eq!(price.format_with_precision(2), "10000.00");
+}
+
+#[test]
+fn okx_ticker_message_converts_last_price_to_price() {
+    let updates = match parse_okx_ticker_updates(
+        r#"{
+            "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+            "data": [
+                {
+                    "instType": "SPOT",
+                    "instId": "BTC-USDT",
+                    "last": "9999.99",
+                    "ts": "1597026383085"
+                }
+            ]
+        }"#,
+    ) {
+        Ok(updates) => updates,
+        Err(e) => panic!("ticker message should parse: {e}"),
+    };
+
+    assert_eq!(
+        updates,
+        vec![OkxTicker {
+            pair: "BTC-USDT".to_string(),
+            last: price("9999.99"),
+        }]
+    );
+}
+
+#[test]
+fn okx_subscription_ack_is_ignored() {
+    let updates = match parse_okx_ticker_updates(
+        r#"{
+            "event": "subscribe",
+            "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+            "connId": "a4d3ae55"
+        }"#,
+    ) {
+        Ok(updates) => updates,
+        Err(e) => panic!("subscription acknowledgement should parse: {e}"),
+    };
+
+    assert!(updates.is_empty());
+}
+
+#[test]
+fn okx_subscription_ack_validates_pair_and_channel() {
+    let response = parse_okx_subscription_response(
+        r#"{
+            "id": "ticker-0",
+            "event": "subscribe",
+            "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+            "connId": "a4d3ae55"
+        }"#,
+    )
+    .expect("valid acknowledgement");
+    assert_eq!(
+        response,
+        Some(OkxSubscriptionResponse::Acknowledged {
+            request_id: "ticker-0".to_string(),
+            pair: "BTC-USDT".to_string(),
+        })
+    );
+
+    let error = parse_okx_subscription_response(
+        r#"{"id":"ticker-0","event":"subscribe","arg":{"channel":"books","instId":"BTC-USDT"}}"#,
+    )
+    .expect_err("unexpected channel must fail");
+    assert!(error.to_string().contains("unexpected channel"));
+}
+
+#[test]
+fn subscription_setup_keeps_ticker_when_another_pair_is_rejected() {
+    let mut pending = HashMap::from([
+        ("ticker-0".to_string(), "BTC-USDT".to_string()),
+        ("ticker-1".to_string(), "BAD-USDT".to_string()),
+    ]);
+
+    let acknowledgement = classify_subscription_frame(
+        r#"{
+            "id": "ticker-0",
+            "event": "subscribe",
+            "arg": {"channel": "tickers", "instId": "BTC-USDT"}
+        }"#,
+        &mut pending,
+    )
+    .expect("valid pair should be acknowledged");
+    assert_eq!(
+        acknowledgement,
+        OkxSubscriptionFrame::Acknowledged("BTC-USDT".to_string())
+    );
+
+    let ticker = classify_subscription_frame(
+        r#"{
+            "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+            "data": [{"instId": "BTC-USDT", "last": "9999.99"}]
+        }"#,
+        &mut pending,
+    )
+    .expect("ticker should be processed while another acknowledgement is pending");
+    assert_eq!(
+        ticker,
+        OkxSubscriptionFrame::Updates(vec![OkxTicker {
+            pair: "BTC-USDT".to_string(),
+            last: price("9999.99"),
+        }])
+    );
+
+    let rejection = classify_subscription_frame(
+        r#"{
+            "id": "ticker-1",
+            "event": "error",
+            "code": "60012",
+            "msg": "Invalid request"
+        }"#,
+        &mut pending,
+    )
+    .expect("rejected pair should be isolated by request id");
+    assert!(matches!(
+        rejection,
+        OkxSubscriptionFrame::Rejected { pair, error }
+            if pair == "BAD-USDT" && error.contains("60012")
+    ));
+    assert!(pending.is_empty());
+}
+
+#[test]
+fn malformed_ticker_item_does_not_discard_valid_updates() {
+    let updates = parse_okx_ticker_updates(
+        r#"{
+            "arg": {"channel": "tickers", "instId": "BTC-USDT"},
+            "data": [
+                {"instId": "BTC-USDT", "last": "9999.99"},
+                {"instId": "MISSING-LAST"},
+                {"instId": "BAD-PRICE", "last": "not-a-number"}
+            ]
+        }"#,
+    )
+    .expect("a malformed ticker item should not fail the frame");
+
+    assert_eq!(
+        updates,
+        vec![OkxTicker {
+            pair: "BTC-USDT".to_string(),
+            last: price("9999.99"),
+        }]
+    );
+}
+
+#[test]
+fn okx_error_event_reports_exchange_error() {
+    let error = match parse_okx_ticker_updates(
+        r#"{
+            "event": "error",
+            "code": "60012",
+            "msg": "Invalid request"
+        }"#,
+    ) {
+        Ok(_) => panic!("error event should fail"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("OKX WebSocket error 60012"));
+}
+
+fn price(raw: &str) -> Price {
+    match Price::parse(raw) {
+        Ok(price) => price,
+        Err(e) => panic!("price should parse: {e}"),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@
 //! Set the `RUST_LOG` environment variable to control logging levels:
 //! ```bash
 //! RUST_LOG=debug cargo run
-//! RUST_LOG=exc_okx=debug,okx_streams=debug cargo run
+//! RUST_LOG=okk=debug cargo run
 //! ```
 
 use okk::{Config, ExchangeClient, TrayUI};
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
     let fmt = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
         .with_filter(tracing_subscriber::EnvFilter::new(
-            std::env::var("RUST_LOG").unwrap_or_else(|_| "exc_okx=debug,okx_streams=debug".into()),
+            std::env::var("RUST_LOG").unwrap_or_else(|_| "okk=info".into()),
         ));
     tracing_subscriber::registry().with(fmt).init();
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -97,7 +97,11 @@ impl TrayUI {
                     connection_status = "Connected";
 
                     // Use more efficient string formatting to reduce allocations
-                    let title = format!("{}: ${:.2}", price_update.pair, price_update.price);
+                    let title = format!(
+                        "{}: ${}",
+                        price_update.pair,
+                        price_update.price.format_with_precision(2)
+                    );
                     if let Some(ref mut tray) = tray_icon {
                         tray.set_title(Some(&title));
                     }


### PR DESCRIPTION
## Summary

- Replaced the `exc`/`positions` ticker stream with a direct OKX public WebSocket ticker client.
- Added local OKX subscription parsing and price conversion coverage, including ticker payloads, subscribe acknowledgements, error events, and fixed-precision tray formatting.
- Removed `rust_decimal` and refreshed the lockfile so `positions`, `serde_with`, and the optional `rkyv` audit path are no longer resolved.
- Updated README and logging defaults to describe the local OKX client.

Closes #14

## Validation

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo audit` (no vulnerabilities; allowed warnings remain from existing UI/image transitive crates)
- [x] `cargo tree -i serde_with --locked` reports package not found
- [x] `cargo tree -i positions --locked` reports package not found
- [x] Scope guard: 6 files changed, 923 added lines against `origin/main` (limit: 30 files, 1500 added lines)
